### PR TITLE
Fix RMSE logging in models

### DIFF
--- a/models/dave2_legacy/model.py
+++ b/models/dave2_legacy/model.py
@@ -46,7 +46,7 @@ class Dave2(pl.LightningModule):
         pred = self.forward(x=img)
         loss = self.loss(pred, true)
         self.log("train/loss", loss, prog_bar=True, on_step=True)
-        self.log("train/rmse", math.sqrt(loss), prog_bar=True, on_step=True)
+        self.log("train/rmse", torch.sqrt(loss), prog_bar=True, on_step=True)
         return loss
 
     def validation_step(self, batch: Tensor, batch_idx: int, dataloader_idx: int = 0):
@@ -54,7 +54,7 @@ class Dave2(pl.LightningModule):
         pred = self(img)
         loss = self.loss(pred, true)
         self.log("val/loss", loss, prog_bar=True, on_epoch=True)
-        self.log("val/rmse", math.sqrt(loss), prog_bar=True, on_epoch=True)
+        self.log("val/rmse", torch.sqrt(loss), prog_bar=True, on_epoch=True)
         return loss
 
     def test_step(self, batch: Tensor, batch_idx: int, dataloader_idx: int = 0):
@@ -62,7 +62,7 @@ class Dave2(pl.LightningModule):
         pred = self(img)
         loss = self.loss(pred, true)
         self.log("test/loss", loss, prog_bar=True)
-        self.log("test/rmse", math.sqrt(loss), prog_bar=True)
+        self.log("test/rmse", torch.sqrt(loss), prog_bar=True)
         return loss
 
     def predict_step(self, batch: Tensor, batch_idx: int, dataloader_idx: int = 0):

--- a/models/vit/model.py
+++ b/models/vit/model.py
@@ -1,4 +1,3 @@
-import math
 from typing import Tuple
 
 import lightning as pl
@@ -62,7 +61,7 @@ class ViT(pl.LightningModule):
         loss = self.alpha_steer * loss_s + (1 - self.alpha_steer) * loss_t
 
         self.log("train/loss", loss, prog_bar=True, on_step=True)
-        self.log("train/rmse", math.sqrt(loss), prog_bar=True, on_step=True)
+        self.log("train/rmse", torch.sqrt(loss), prog_bar=True, on_step=True)
         return loss
 
     def validation_step(self, batch, batch_idx):
@@ -77,7 +76,7 @@ class ViT(pl.LightningModule):
         loss = self.alpha_steer * loss_s + (1 - self.alpha_steer) * loss_t
 
         self.log("val/loss", loss, prog_bar=True, on_epoch=True)
-        self.log("val/rmse", math.sqrt(loss), prog_bar=True, on_epoch=True)
+        self.log("val/rmse", torch.sqrt(loss), prog_bar=True, on_epoch=True)
 
     def test_step(self, batch, batch_idx):
         imgs, targets = batch
@@ -91,7 +90,7 @@ class ViT(pl.LightningModule):
         loss = self.alpha_steer * loss_s + (1 - self.alpha_steer) * loss_t
 
         self.log("test/loss", loss, prog_bar=True)
-        self.log("test/rmse", math.sqrt(loss), prog_bar=True)
+        self.log("test/rmse", torch.sqrt(loss), prog_bar=True)
 
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=self.learning_rate)


### PR DESCRIPTION
## Summary
- compute RMSE using `torch.sqrt` instead of `math.sqrt`
- remove unused `math` import

## Testing
- `pytest -q`
- `python -m py_compile models/vit/model.py models/dave2_legacy/model.py`


------
https://chatgpt.com/codex/tasks/task_e_684aa17afff0832dba52e9966bcd0a9c